### PR TITLE
Add api requirements and use cases

### DIFF
--- a/archive_communication/api-requirements.md
+++ b/archive_communication/api-requirements.md
@@ -1,0 +1,324 @@
+# API Requirements
+
+This document outlines some general requirements for APIs that would be necessary
+for communication between BCDC, data archives, and other partners for one- or
+two-way communication. These requirements don't mandate a specific implementation, 
+but do make some assumptions around higher level design:
+
+## Assumptions
+- This document and the examples make a few assumptions about the APIs:
+    - APIs communicate via JSON over HTTP
+    - APIs roughly follow REST principles
+
+## General Requirements
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-g7sd">#</th>
+    <th class="tg-g7sd">Requirement</th>
+    <th class="tg-g7sd">Description</th>
+    <th class="tg-g7sd">Priority</th>
+    <th class="tg-g7sd">Notes</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-lboi">1</td>
+    <td class="tg-lboi">Individual user authentication</td>
+    <td class="tg-lboi">If the API requires authentication, an individual user can authenticate themselves with an API Key or OAuth access token to interact with the API.</td>
+    <td class="tg-lboi">Should have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>Preferred OAuth mechanism would be ORCID.</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">2</td>
+    <td class="tg-lboi">Service account authentication</td>
+    <td class="tg-lboi">A downstream service can authenticate with an API Key to automate interactions with the API.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi"></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">3</td>
+    <td class="tg-lboi">Consistent, persistent identifier for objects</td>
+    <td class="tg-lboi">A user or service should be able to access an object using the same identifying URI each time.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi"></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">4</td>
+    <td class="tg-lboi">Object schema documentation</td>
+    <td class="tg-lboi">Objects fetched from API contain links to the schema used to generate/validate objects.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>JSONSchema preferred</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">5</td>
+    <td class="tg-lboi">Versioned data schemas</td>
+    <td class="tg-lboi">Schemas should have versions so as the schemas change, we can track which schema was used to generate/validate objects.</td>
+    <td class="tg-lboi">Should have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>JSONSchema preferred</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">6</td>
+    <td class="tg-lboi">Related objects are easily findable from a given object</td>
+    <td class="tg-lboi">Objects contain resource IDs or resource URIs for related objects.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li> Supports use case <a href="api-use-cases.md"> Data inventory – new project</a>
+            <li><a href="#related-objects">See example</a></li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">7</td>
+    <td class="tg-lboi">Consistent response status codes</td>
+    <td class="tg-lboi">API responses should contain appropriate, standardized status codes.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>
+                <a href="https://datatracker.ietf.org/doc/html/rfc2616"> 
+                    Proposed standard: IETF RFC 2616
+                </a>
+            </li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">8</td>
+    <td class="tg-lboi">API endpoint documentation</td>
+    <td class="tg-lboi">Public endpoints should be documented with expected request params and sample responses.</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi"></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">9</td>
+    <td class="tg-lboi">Filtering results</td>
+    <td class="tg-lboi">Results for API calls can be filtered via query string or filters specified in the request body.</td>
+    <td class="tg-lboi">Nice to have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li><a href="#filtering-results">See example</a></li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">10</td>
+    <td class="tg-lboi">Searching by BCDC identifier</td>
+    <td class="tg-lboi">A user should be able to find a resource using the resource's BCDC identifier</td>
+    <td class="tg-lboi">Must have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>
+                Supports use case: <a href="api-use-cases.md"> Data inventory – registered projects </a>
+            </li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">11</td>
+    <td class="tg-lboi">Searching by metadata</td>
+    <td class="tg-lboi">Search for data sets using parameters like grant number, species, technique, etc.</td>
+    <td class="tg-lboi">Nice to have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li><a href="#searching"> See example </a></li>
+            <li>Supports use case: <a href="api-use-cases.md"> Search – filter for projects</a></li>
+            <li> Supports use case: <a href="api-use-cases.md">Search – filter for samples</a></li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">12</td>
+    <td class="tg-lboi">Validation exceptions</td>
+    <td class="tg-lboi">If a dataset did not pass schema validation or meet a data standard, the API should message an exception when querying the dataset.</td>
+    <td class="tg-lboi">Should have</td>
+    <td class="tg-lboi">
+        <ul>
+            <li>Supports use case <a href="api-use-cases.md"> Validation </a></li>
+        </ul>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+## NeMO Specific Requirements
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-yla0">#</th>
+    <th class="tg-yla0">Requirement</th>
+    <th class="tg-yla0">Description</th>
+    <th class="tg-yla0">Priority</th>
+    <th class="tg-yla0">Notes</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-cly1">1</td>
+    <td class="tg-cly1">NeMO landing page and manifest metadata are available from data collection resource</td>
+    <td class="tg-cly1">Once a data collection resource is found, a user should be able to navigate to the corresponding landing page and the manifest from the data collection’s metadata.</td>
+    <td class="tg-cly1">Must have</td>
+    <td class="tg-cly1"></td>
+  </tr>
+  <tr>
+    <td class="tg-cly1">2</td>
+    <td class="tg-cly1">NeMO collection identifier searchable or filterable using metadata</td>
+    <td class="tg-cly1">A user should be able to find a data collection identifier using metadata such as technique, author, grant etc.</td>
+    <td class="tg-cly1">Nice to have</td>
+    <td class="tg-cly1"></td>
+  </tr>
+</tbody>
+</table>
+
+## Examples
+
+### Related objects
+---
+
+
+```json
+GET https://example.com/api/project/project1
+
+{
+    "id": "project1",
+    "title": "Some title",
+    "description": "Some description",
+    "dataCollections": [
+        {
+            "id": "dataCollection1",
+            "uri": "https://example.com/api/dataCollection/dataCollection1",
+        },
+        {
+            "id": "dataCollection2",
+            "uri": "https://example.com/api/dataCollection/dataCollection2",
+        }
+    ]
+}
+```
+
+```json
+GET https://example.com/api/dataCollection/dataCollection1
+
+{
+    "id": "dataCollection1",
+    "title": "Some other title",
+    "description": "Some other description",
+    "projects": [
+        {
+            "id": "project1",
+            "uri": "https://example.com/api/project/project1"
+        },
+        {
+            "id": "project2",
+            "uri": "https://example.com/api/project/project2"
+        }
+    ],
+    "assets": [
+       {
+         "id": "imageFile1",
+         "uri": "https://example.com/api/asset/imageFile1"
+       },
+       {
+        "id": "fastqFile1",
+        "uri": "https://example.com/api/asset/fastqFile1"
+       }
+    ]
+}
+```
+
+```json
+GET https://example.com/api/asset/imageFile1
+
+{
+    "id": "imageFile1",
+    "filename": "some_filename.tiff",
+    "extension": ".tiff",
+    "dataCollections": [
+        {
+            "id": "dataCollection1",
+            "uri": "https://example.com/api/dataCollection/dataCollection1",
+        },
+        {
+            "id": "dataCollection2",
+            "uri": "https://example.com/api/dataCollection/dataCollection2",
+        }
+    ]
+}
+```
+
+### Filtering results
+---
+```json
+//Filtering via query string
+GET https://example.com/api/assets?dataCollection=dataCollection1&fileType=txt
+
+{
+    "assets": [
+        {
+            "id": "asset1",
+            "title": "Sample title",
+            "uri": "https://example.com/api/asset/asset1",
+            "dataCollections" : [
+                {
+                    "id": "dataCollection1",
+                    "uri": "https://example/com/api/dataCollection/dataCollection1"
+                }
+            ]
+            "fileType": "txt"
+        },
+        {
+            "id": "asset2",
+            "title": "Sample title",
+            "uri": "https://example.com/api/asset/asset2",
+            "dataCollections" : [
+                {
+                    "id": "dataCollection1",
+                    "uri": "https://example/com/api/dataCollection/dataCollection1"
+                }
+            ]
+            "fileType": "txt"
+        }
+    ]
+}
+
+```
+### Searching
+---
+```json
+GET https://example.com/api/search?q=marmoset
+
+{
+    "projects": [
+        {
+            "id": "project1",
+            "uri": "https://example.com/api/project/project1"
+        }
+    ],
+    "dataCollections": [
+        {
+            "id": "dataCollection1",
+            "uri": "https://example.com/api/dataCollection/dataCollection1"
+        }
+    ],
+    ...
+}
+
+```
+
+
+

--- a/archive_communication/api-use-cases.md
+++ b/archive_communication/api-use-cases.md
@@ -1,0 +1,248 @@
+# API Use Cases
+
+This document outlines use cases for APIs at archives. Requirements supporting the
+use cases are documented in a separate [requirements doc](api-requirements.md).
+
+
+<table id="new-project" class="tg">
+<thead>
+  <tr>
+    <th class="tg-0pky">Use case #</th>
+    <th class="tg-0pky">1</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0pky">Name</td>
+    <td class="tg-0pky">Data inventory – new project</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky">Actors</td>
+    <td class="tg-0pky">BCDC service account</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky">Description</td>
+    <td class="tg-0pky">
+        <ul>
+            <li>
+                BCDC wants to collect the metadata of a new project that has not yet been registered with BCDC, and has already submitted data to an archive.
+            </li>
+            <li>
+                <span>The BCDC service account queries the archive’s API using the archive’s local identifier for the given project to retrieve metadata. 
+                See <a href="https://github.com/BICCN/BCDC-Metadata/blob/83b00c19d21a7ef73196936a7b8e66b8637e59ee/design/schema/mappings.csv">schema mapping document</a> for a work in progress map between BCDC and archive schemas.</span>
+            </li>
+        </ul>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+<table id="registered-projects" class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax">Use case #</th>
+    <th class="tg-0lax">2</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax">Name</td>
+    <td class="tg-0lax">Data inventory – registered projects</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Actors</td>
+    <td class="tg-0lax">BCDC service account</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Description</td>
+    <td class="tg-0lax">
+        <ul>
+            <li>
+                BCDC wants to update the metadata of all projects that are currently registered with the BCDC and submitting data to a given archive.
+            </li>
+            <li>
+                <span>
+                    The BCDC service account queries the archive’s API using the project’s BCDC identifier to retrieve metadata for a given project. See <a href="https://github.com/BICCN/BCDC-Metadata/blob/83b00c19d21a7ef73196936a7b8e66b8637e59ee/design/schema/mappings.csv">schema mapping document</a> for a work in progress map between BCDC and archive schemas.
+                </span>
+            </li>
+        </ul>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+<table id="samples" class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax">Use case #</th>
+    <th class="tg-0lax">3</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax">Name</td>
+    <td class="tg-0lax">Data inventory – samples</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Actors</td>
+    <td class="tg-0lax">BCDC service account</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Description</td>
+    <td class="tg-0lax">
+    <ul>
+        <li>
+            BCDC wants to gather an inventory of all samples submitted to an archive for a given project registered with BCDC.
+        </li>
+        <li>
+            BCDC’s service account queries the archive’s API for a project using either the BCDC identifier or the archive’s local identifier to retrieve a project’s metadata.
+        </li>
+        <li>
+            <span>
+                The project’s metadata contains a list of references to samples submitted for the project. The service account queries the API using the sample references and retrieves associated metadata. See <a href="https://github.com/BICCN/BCDC-Metadata/tree/master/Templates/sample_inventory"> specimen templates</a> for example metadata collected by BCDC.
+            </span>
+        </li>
+    </ul>
+  </tr>
+</tbody>
+</table>
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax">Use case #</th>
+    <th class="tg-0lax">4</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax">Name</td>
+    <td class="tg-0lax">Data inventory – asset manifests</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Actors</td>
+    <td class="tg-0lax">BCDC service account</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Description</td>
+    <td class="tg-0lax">
+        <ul>
+            <li>
+                BCDC wants to gather an inventory of all assets submitted to an archive for a given project registered with BCDC.
+            </li>
+            <li>
+                BCDC’s service account queries the archive’s API to using either the BCDC identifier or the archive’s local identifier to retrieve a project’s metadata.
+            </li>
+            <li>
+                The project’s metadata includes a list of references to assets submitted. The service account queries the API using the asset references and retrieves associated metadata. Metadata include:
+            </li>
+                <ul>
+                    <li>asset_id</li>
+                    <li>asset_name</li>
+                    <li>project_id</li>
+                    <li>data_collection_id</li>
+                    <li>asset_name</li>
+                    <li>sample_id</li>
+                    <li>URI</li>
+                    <li>Filetype</li>
+                    <li>Filesize</li>
+                    <li>Checksum</li>
+                    <li>Checksum type (SHA256, md5 etc)</li>
+                </ul>
+        </ul>
+  </tr>
+</tbody>
+</table>
+
+<table class="tg">
+    <thead>
+    <tr>
+        <th class="tg-0lax">Use case #</th>
+        <th class="tg-0lax">5</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td class="tg-0lax">Name</td>
+        <td class="tg-0lax">Search – filter for projects</td>
+    </tr>
+    <tr>
+        <td class="tg-0lax">Actors</td>
+        <td class="tg-0lax">Scientist</td>
+    </tr>
+    <tr>
+        <td class="tg-0lax">Description</td>
+        <td class="tg-0lax">
+            <ul>
+                <li>
+                    A scientist wants to find projects that use a particular technique, modality, or contain a specific type of sample.
+                </li>
+                <li>
+                    They query the archive’s API using filters to retrieve a list of projects and associated metadata.
+                </li>
+            </ul>
+    </tr>
+    </tbody>
+</table>
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax">Use case #</th>
+    <th class="tg-0lax">6</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax">Name</td>
+    <td class="tg-0lax">Search – filter for samples</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Actors</td>
+    <td class="tg-0lax">Scientist</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Description</td>
+    <td class="tg-0lax">
+        <ul>
+            <li>
+                A scientist wants to find samples that were extracted from a specific anatomical region of a particular species of animal.
+            </li>
+            <li>
+                They query the archive’s API using filters to retrieve a list of samples and the associated metadata. Metadata includes a reference either via ID or URI to the associated projects and assets.
+            </li>
+        </ul>
+  </tr>
+</tbody>
+</table>
+
+<table class="tg">
+<thead>
+  <tr>
+    <th class="tg-0lax">Use case #</th>
+    <th class="tg-0lax">7</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0lax">Name</td>
+    <td class="tg-0lax">Validation</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Actors</td>
+    <td class="tg-0lax">BCDC Service Account</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Description</td>
+    <td class="tg-0lax">
+        <ul>
+            <li>
+                BCDC wants to ingest a project’s samples for the inventory, but the samples submitted did not pass validation during ingest into the archives’ system.
+            </li>
+            <li>
+                The service account queries a project and associated samples through the API and receives an Exception message that the samples did not pass validation.
+            </li>
+        </ul>
+  </tr>
+</tbody>
+</table>


### PR DESCRIPTION
This PR adds:
- a document that outlines use cases for communication between BCDC and archives via APIs
- a requirements document supporting the use cases